### PR TITLE
use the newer 'babel' instead of 6to5

### DIFF
--- a/lib/generators/webpack_rails/templates/package.json
+++ b/lib/generators/webpack_rails/templates/package.json
@@ -5,7 +5,7 @@
     "node": ">= 0.10"
   },
   "dependencies": {
-    "6to5-loader": "^3.0.0",
+    "babel-loader": "^4.1.0",
     "assets-webpack-plugin": "^0.1.0",
     "coffee-loader": "^0.7.2",
     "coffee-script": "^1.9.0",

--- a/lib/generators/webpack_rails/templates/webpack.config.js
+++ b/lib/generators/webpack_rails/templates/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
   },
   module: {
     loaders: [
-      { test: /\.js?$/, exclude: [/node_modules/, /vendor/], loader: '6to5-loader' },
+      { test: /\.js?$/, exclude: [/node_modules/, /vendor/], loader: 'babel-loader' },
     ]
   },
   cache: true,


### PR DESCRIPTION
This is the loader recommended in the docs: https://babeljs.io/docs/using-babel/#webpack
