### PR TITLE
get the port number for running the webpack dev server

### DIFF
--- a/lib/tasks/webpack_rails_tasks.rake
+++ b/lib/tasks/webpack_rails_tasks.rake
@@ -9,6 +9,6 @@ namespace :webpack_rails do
   end
 
   task :dev_server do
-    sh %q[./node_modules/.bin/webpack-dev-server --port $(rails runner "puts WebpackRails.config.dev_server_port")]
+    sh "./node_modules/.bin/webpack-dev-server --port #{WebpackRails.config.dev_server_port}"
   end
 end


### PR DESCRIPTION
This line was giving me errors and not giving me the port number. This change seemed to fix it for me.
